### PR TITLE
fix: instalación en Odoo 19 (claims_view type list + cron sin numbercall)

### DIFF
--- a/data/claims_cron.xml
+++ b/data/claims_cron.xml
@@ -15,7 +15,6 @@
             <field name="code">model.cron_sync_claims(status="opened", limit=50)</field>
             <field name="interval_number">6</field>
             <field name="interval_type">hours</field>
-            <field name="numbercall">-1</field>
             <field name="active" eval="False"/>
         </record>
     </data>

--- a/views/claims_view.xml
+++ b/views/claims_view.xml
@@ -5,7 +5,7 @@
         <record model="ir.ui.view" id="view_meli_claims_tree">
             <field name="name">mercadolibre.claim.tree</field>
             <field name="model">mercadolibre.claim</field>
-            <field name="type">tree</field>
+            <field name="type">list</field>
             <field name="arch" type="xml">
                 <list string="Reclamos" default_order="date_created desc" create="0">
                     <field name="claim_id"/>


### PR DESCRIPTION
Corrige la instalación de la rama 19.0 en Odoo 19 Community (hoy falla con `ParseError`; detalle completo en el issue #129):

- `views/claims_view.xml`: `type` de la vista de reclamos `tree` → `list` (renombrado en Odoo 19).
- `data/claims_cron.xml`: se elimina `numbercall` (campo inexistente en `ir.cron` desde Odoo 17; `-1` era "sin límite", que es el default actual).

Probado en Odoo 19.0 Community (Docker `odoo:19`): el módulo instala y funciona (conexión OAuth, crons y sincronización verificados en una instancia productiva).

Closes #129
